### PR TITLE
fix: longformer like model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jinaai/jina:2.0.3
+FROM jinaai/jina:2.0-perf
 
 RUN apt-get -y update && apt-get install -y git
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -5,6 +5,7 @@ RUN apt update && apt install -y python3.8 python3-pip
 COPY . ./transformer-text-encoder/
 WORKDIR ./transformer-text-encoder
 
+RUN pip install jina[perf]>=2.0
 RUN pip install .
 
 ENTRYPOINT ["jina", "executor", "--uses", "config.yml"]

--- a/tests/unit/test_encoder.py
+++ b/tests/unit/test_encoder.py
@@ -20,11 +20,14 @@ def test_compute_tokens():
     assert tokens["attention_mask"].shape == (2, 7)
 
 
-def test_compute_embeddings():
+@pytest.mark.parametrize(
+    'hidden_seqlen', [4, 8]
+)
+def test_compute_embeddings(hidden_seqlen):
     embedding_size = 10
     enc = TransformerTorchEncoder()
     tokens = enc._generate_input_tokens(["hello world"])
-    hidden_states = tuple(torch.zeros(1, 4, embedding_size) for _ in range(7))
+    hidden_states = tuple(torch.zeros(1, hidden_seqlen, embedding_size) for _ in range(7))
 
     embeddings = enc._compute_embedding(
         hidden_states=hidden_states, input_tokens=tokens

--- a/transform_encoder.py
+++ b/transform_encoder.py
@@ -82,7 +82,7 @@ class TransformerTorchEncoder(Executor):
         )
         layer = hidden_states[self.layer_index]
 
-        attn_mask = inputs['attention_mask']
+        attn_mask = input_tokens['attention_mask']
 
         # Fix LongFormerModel like model which has mismatch seq_len between
         # attention_mask and hidden_states
@@ -92,7 +92,7 @@ class TransformerTorchEncoder(Executor):
 
         expand_attn_mask = attn_mask.unsqueeze(-1).expand_as(layer)
 
-        layer = torch.where(attn_mask.bool(), layer, fill_val)
+        layer = torch.where(expand_attn_mask.bool(), layer, fill_val)
         embeddings = layer.sum(dim=1) / expand_attn_mask.sum(dim=1)
         return embeddings.cpu().numpy()
 

--- a/transform_encoder.py
+++ b/transform_encoder.py
@@ -39,7 +39,7 @@ class TransformerTorchEncoder(Executor):
         max_length: Optional[int] = None,
         embedding_fn_name: str = '__call__',
         device: str = 'cpu',
-        num_threads: int = 1,
+        num_threads: Optional[int] = None,
         default_traversal_paths: Optional[List[str]] = None,
         default_batch_size: int = 32,
         *args,
@@ -69,10 +69,10 @@ class TransformerTorchEncoder(Executor):
             )
             device = 'cpu'
 
-        if device == 'cpu':
+        if device == 'cpu' and num_threads:
             cpu_num = os.cpu_count()
             if num_threads > cpu_num:
-                self.logger.warning(f'You tried to use {num_threads} threads > {cpu_num} CPU cores')
+                self.logger.warning(f'You tried to use {num_threads} threads > {cpu_num} CPUs')
             else:
                 os.environ['OMP_NUM_THREADS'] = str(num_threads)
                 os.environ['OPENBLAS_NUM_THREADS'] = str(num_threads)

--- a/transform_encoder.py
+++ b/transform_encoder.py
@@ -39,7 +39,7 @@ class TransformerTorchEncoder(Executor):
         max_length: Optional[int] = None,
         embedding_fn_name: str = '__call__',
         device: str = 'cpu',
-        num_threads: int = 8,
+        num_threads: int = 1,
         default_traversal_paths: Optional[List[str]] = None,
         default_batch_size: int = 32,
         *args,

--- a/transform_encoder.py
+++ b/transform_encoder.py
@@ -39,7 +39,7 @@ class TransformerTorchEncoder(Executor):
         max_length: Optional[int] = None,
         embedding_fn_name: str = '__call__',
         device: str = 'cpu',
-        num_threads: int = 1,
+        num_threads: int = 8,
         default_traversal_paths: Optional[List[str]] = None,
         default_batch_size: int = 32,
         *args,
@@ -70,11 +70,15 @@ class TransformerTorchEncoder(Executor):
             device = 'cpu'
 
         if device == 'cpu':
-            os.environ['OMP_NUM_THREADS'] = str(num_threads)
-            os.environ['OPENBLAS_NUM_THREADS'] = str(num_threads)
-            os.environ['MKL_NUM_THREADS'] = str(num_threads)
+            cpu_num = os.cpu_count()
+            if num_threads > cpu_num:
+                self.logger.warning(f'You tried to use {num_threads} threads > {cpu_count} CPU cores')
+            else:
+                os.environ['OMP_NUM_THREADS'] = str(num_threads)
+                os.environ['OPENBLAS_NUM_THREADS'] = str(num_threads)
+                os.environ['MKL_NUM_THREADS'] = str(num_threads)
 
-            torch.set_num_threads(num_threads)
+                torch.set_num_threads(num_threads)
 
         self.device = device
         self.embedding_fn_name = embedding_fn_name

--- a/transform_encoder.py
+++ b/transform_encoder.py
@@ -72,7 +72,7 @@ class TransformerTorchEncoder(Executor):
         if device == 'cpu':
             cpu_num = os.cpu_count()
             if num_threads > cpu_num:
-                self.logger.warning(f'You tried to use {num_threads} threads > {cpu_count} CPU cores')
+                self.logger.warning(f'You tried to use {num_threads} threads > {cpu_num} CPU cores')
             else:
                 os.environ['OMP_NUM_THREADS'] = str(num_threads)
                 os.environ['OPENBLAS_NUM_THREADS'] = str(num_threads)


### PR DESCRIPTION
```
import torch
from transformers import AutoModel, AutoTokenizer

tokenizer = AutoTokenizer.from_pretrained('hfl/chinese-roberta-wwm-ext')
model = AutoModel.from_pretrained('xcjthu/Lawformer', output_hidden_states=True)

inputs = tokenizer(['我发生了交通事故,我骑自行车'], padding=True, return_tensors='pt')

outputs = model(**inputs)
layer = outputs.hidden_states[-1]

print(f'input_shape: {attn_mask.shape} vs output_shape: {layer.shape}')

```

The output:
```
input_shape: torch.Size([1, 16]) vs output_shape: torch.Size([1, 512, 768])
```

The seq_length between input and output does not match in the above case.